### PR TITLE
P12: do not check number of neighbors of I

### DIFF
--- a/agh_graphs/productions/p12.py
+++ b/agh_graphs/productions/p12.py
@@ -78,10 +78,6 @@ class P12(Production):
             if lower_interior not in neighbors_in_lower_layer[prod_input[0]]\
               and lower_interior not in neighbors_in_lower_layer[prod_input[1]]:
                 raise ValueError('Upper interiors not connected to lower ones')
-        if len(neighbors_in_lower_layer[prod_input[0]]) != 1:
-            raise ValueError('Upper interiors connected to too many lower ones')
-        if len(neighbors_in_lower_layer[prod_input[1]]) != 1:
-            raise ValueError('Upper interiors connected to too many lower ones')
 
         # maps lower interiors to its parent in upper layer
         lower_to_upper = dict()


### PR DESCRIPTION
This check was unnecessary as the I vertices
from the upper layer may be connected to more
then one vertex from the lower layer.